### PR TITLE
Metadata server prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,16 +22,14 @@ This module contains:
 * Classes to configure Cassandra cluster nodes for testing and development
 * Tasks for initializing a Cassandra schema for the Puppet metadata service
 * Tasks to perform CRUD operations on data in the Puppet metadata service
-* TODO: Hiera 5 backend for the Puppet metadata service
-* TODO: `trusted_external_command` integration for the Puppet metadata service
+* Hiera 5 backend for the Puppet metadata service
+* trusted_external_command` integration for the Puppet metadata service
 
 ## Setup
 
 ### Setup Requirements
 
-If your module requires anything extra before setting up (pluginsync enabled, another module, etc.), mention it here.
-
-If your most recent release breaks compatibility or requires particular steps for upgrading, you might want to include an additional "Upgrading" section here.
+`puppetserver gem install cassandra-driver`
 
 ### Beginning with puppet_metadata_service
 

--- a/lib/puppet/functions/puppet_metadata_service/data_hash.rb
+++ b/lib/puppet/functions/puppet_metadata_service/data_hash.rb
@@ -1,30 +1,58 @@
 # /etc/puppetlabs/code/environments/production/modules/mymodule/lib/puppet/functions/mymodule/upcase.rb
-require 'cassandra'
 require 'json'
 require 'yaml'
 
+begin
+  require 'cassandra'
+rescue LoadError => e
+  raise Puppet::DataBinding::LookupError, "[puppet_metadata_service::data_hash] Must install cassandra-driver gem to use this backend"
+end
+
 Puppet::Functions.create_function(:'puppet_metadata_service::data_hash') do
 
-  dispatch :hiera_backend do
+  dispatch :hiera_data do
     param 'Hash', :options
     param 'Puppet::LookupContext', :context
   end
 
-  def hiera_backend(options, context)
-    session = context.cached_value(:session)
-
-    if session.nil?
-      session = new_session
-      context.cache(:session, session)
+  def sessionadapter
+    @sessionadapter ||= Class.new(Puppet::Pops::Adaptable::Adapter) do
+      attr_accessor :session
+      def self.name()
+        "Puppet_metadata_service::Data_hash::SessionAdapter"
+      end
     end
+    @sessionadapter
   end
 
-  def new_session
-    # TODO
-  end
+  def hiera_data(options, context)
+    uri = options['uri']
+    hosts = hosts.nil? ? Array(Socket.gethostname) : Array(options['hosts'])
 
-  def get_level_data(level, session)
-    # TODO
-  end
+    adapter = sessionadapter.adapt(closure_scope().environment)
 
+    if adapter.session.nil?
+      context.explain { '[puppet_metadata_service::data_hash] Database connection not cached...establishing...' }
+      begin
+        context.explain { "[puppet_metadata_service::data_hash] Database connection established to #{hosts.join(', ')}" }
+        adapter.session = Cassandra.cluster(hosts: hosts).connect('puppet')
+      rescue Cassandra::Error => e
+        adapter.session = nil
+        context.explain { '[puppet_metadata_service::data_hash] Failed to establish database connection' }
+        return {}
+      end
+    else
+      context.explain { '[puppet_metadata_service::data_hash] Re-using established database connection from cache' }
+    end
+
+    session = adapter.session
+
+    data = session.execute(
+      "SELECT key,value FROM hieradata where level=%s" % "$$#{uri}$$").rows.map { |row|
+        { row['key'] => row['value'] }
+      }.reduce({}, :merge
+    )
+
+    return data
+  end
 end

--- a/manifests/cassandra.pp
+++ b/manifests/cassandra.pp
@@ -32,5 +32,39 @@ class puppet_metadata_service::cassandra (
       }],
     },
   }
-
+  class { 'cassandra::schema':
+    cqlsh_password => 'cassandra',
+    cqlsh_user     => 'cassandra',
+    cqlsh_host     => $::ipaddress,
+    keyspaces      => {
+      'puppet' => {
+        durable_writes  => false,
+        replication_map => {
+          keyspace_class     => 'SimpleStrategy',
+          replication_factor => 1,
+        },
+      }
+    },
+    tables         => {
+      'nodedata' => {
+        columns  => {
+          certname      => 'text',
+          environment   => 'text',
+          release       => 'text',
+          classes       => 'set<text>',
+          'PRIMARY KEY' => '(certname)'
+        },
+        keyspace => 'puppet'
+      },
+      'hieradata' => {
+        columns  => {
+          level         => 'text',
+          key           => 'text',
+          value         => 'text',
+          'PRIMARY KEY' => '(level, key)'
+        },
+        keyspace => 'puppet'
+      }
+    }
+  }
 }

--- a/manifests/puppetserver.pp
+++ b/manifests/puppetserver.pp
@@ -8,16 +8,25 @@ class puppet_metadata_service::puppetserver {
     source => 'puppet:///modules/puppet_metadata_service/get-nodedata.rb',
   }
 
+  $hosts = puppetdb_query('resources[certname] { type = "Class" and title = "Puppet_metadata_service::Cassandra" }').map |$resource| {
+    $resource['certname']
+  }.sort
+
   file { '/etc/puppetlabs/puppet/puppet-metadata-service.yaml':
     ensure  => file,
     owner   => 'pe-puppet',
     group   => 'pe-puppet',
     mode    => '0640',
     content => epp('puppet_metadata_service/puppet-metadata-service.yaml.epp', {
-
+      hosts => $hosts
     }),
   }
 
-  # TODO: ini_setting for puppet.conf to use it
-
+  pe_ini_setting { 'puppetserver puppetconf trusted external script':
+    ensure  => present,
+    path    => '/etc/puppetlabs/puppet/puppet.conf',
+    setting => 'trusted_external_command',
+    value   => '/etc/puppetlabs/puppet/get-nodedata.rb',
+    section => 'master',
+  }
 }

--- a/tasks/create_sample_data.sh
+++ b/tasks/create_sample_data.sh
@@ -1,21 +1,21 @@
 #!/bin/bash
 
 cqlsh $(hostname -f) <<EOF
-  INSERT INTO puppet.nodedata (certname, environment, release) 
+  INSERT INTO puppet.nodedata (certname, environment, release)
   VALUES ('testnode1.example.com', 'production', 'r42');
 
   INSERT INTO puppet.hieradata (level, key, value)
-  VALUES ('nodes/testnode1.example.com', 'class::value1', 'nodes');
+  VALUES ('nodes/testnode1.example.com', 'sample::value1', 'nodes');
 
   INSERT INTO puppet.hieradata (level, key, value)
-  VALUES ('environments/production', 'class::value1', '"environments-prod"');
+  VALUES ('environments/production', 'sample::value1', 'environments-prod');
 
   INSERT INTO puppet.hieradata (level, key, value)
-  VALUES ('environments/production', 'class::value2', '"environments-prod"');
+  VALUES ('environments/production', 'sample::value2', 'environments-prod');
 
   INSERT INTO puppet.hieradata (level, key, value)
-  VALUES ('environments/production', 'class::value3', '"environments-prod"');
+  VALUES ('environments/production', 'sample::value3', 'environments-prod');
 
   INSERT INTO puppet.hieradata (level, key, value)
-  VALUES ('environments/development', 'class::value1', '"environments-dev"');
+  VALUES ('environments/development', 'sample::value1', 'environments-dev');
 EOF

--- a/templates/puppet-metadata-service.yaml.epp
+++ b/templates/puppet-metadata-service.yaml.epp
@@ -1,1 +1,6 @@
-
+<%- | Array $hosts | -%>
+---
+hosts:
+<% $hosts.each |$host| { -%>
+  - <%= $host %>
+<% } -%>


### PR DESCRIPTION
	This commit includes a hiera 5 based backend for doing data
	look ups from a remote cassandra service and a trusted external
	script for obtaing node metadata to facilitate classification
	and code release workflows

	Some Puppet and Task tweaks to support testing