### PR TITLE
Lots'o'changes to make cassandra work

### DIFF
--- a/manifests/cassandra.pp
+++ b/manifests/cassandra.pp
@@ -1,7 +1,8 @@
 class puppet_data_service::cassandra (
   String $seeds          = getvar('facts.ipaddress'),
   String $listen_address = getvar('facts.ipaddress'),
-  String $dc    = 'DC1',
+  String $dc             = 'DC1',
+  String $storage_port   = '7000',
 ) {
 
   # BUG https://issues.apache.org/jira/browse/CASSANDRA-15273
@@ -53,15 +54,16 @@ class puppet_data_service::cassandra (
   }
 
   class { 'cassandra':
-    package_name                    => 'cassandra',
-    service_ensure                  => 'running',
-    dc                              => $dc,
-    settings                        => {
+    package_name   => 'cassandra',
+    service_ensure => 'running',
+    dc             => $dc,
+    settings       => {
       'cluster_name'                => 'PuppetDataCluster',
       'endpoint_snitch'             => 'GossipingPropertyFileSnitch',
       'commitlog_directory'         => '/var/lib/cassandra/commitlog',
       'hints_directory'             => '/var/lib/cassandra/hints',
       'saved_caches_directory'      => '/var/lib/cassandra/saved_caches',
+      'storage_port'                => $storage_port,
       'commitlog_sync'              => 'periodic',
       'commitlog_sync_period_in_ms' => '10000',
       'num_tokens'                  => 256,
@@ -103,7 +105,7 @@ class puppet_data_service::cassandra (
           'PRIMARY KEY' => '(name)'
         },
       },
-      'nodedata' => {
+      'nodedata'     => {
         keyspace => 'puppet',
         columns  => {
           certname      => 'text',
@@ -113,7 +115,7 @@ class puppet_data_service::cassandra (
           'PRIMARY KEY' => '(certname)'
         },
       },
-      'hieradata' => {
+      'hieradata'    => {
         keyspace => 'puppet',
         columns  => {
           level         => 'text',

--- a/metadata.json
+++ b/metadata.json
@@ -2,13 +2,21 @@
   "name": "reidmv-puppet_data_service",
   "version": "0.1.0",
   "author": "Reid Vandewiele",
-  "summary": "",
+  "summary": "Reference implementation of the Puppet Data Service Pattern",
   "license": "Apache-2.0",
-  "source": "",
+  "source": "https://github.com/reidmv/reidmv-puppet_data_service.git",
   "dependencies": [
     {
       "name": "puppetlabs/puppetserver_gem",
       "version_requirement": ">= 1.1.1 < 2.0.0"
+    },
+    {
+      "name": "puppet/cassandra",
+      "version_requirement": ">= 2.7.3"
+    },
+    {
+      "name": "puppetlabs/ruby_task_helper",
+      "version_requirement": ">= 0.5.1"
     }
   ],
   "operatingsystem_support": [

--- a/tasks/create_sample_data.sh
+++ b/tasks/create_sample_data.sh
@@ -5,17 +5,17 @@ cqlsh $(hostname -f) <<EOF
   VALUES ('testnode1.example.com', 'production', 'r42');
 
   INSERT INTO puppet.hieradata (level, key, value)
-  VALUES ('nodes/testnode1.example.com', 'sample::value1', 'nodes');
+  VALUES ('nodes/testnode1.example.com', 'sample::value1', '"nodes"');
 
   INSERT INTO puppet.hieradata (level, key, value)
-  VALUES ('environments/production', 'sample::value1', 'environments-prod');
+  VALUES ('environments/production', 'sample::value1', '"environments-prod"');
 
   INSERT INTO puppet.hieradata (level, key, value)
-  VALUES ('environments/production', 'sample::value2', 'environments-prod');
+  VALUES ('environments/production', 'sample::value2', '"environments-prod"');
 
   INSERT INTO puppet.hieradata (level, key, value)
-  VALUES ('environments/production', 'sample::value3', 'environments-prod');
+  VALUES ('environments/production', 'sample::value3', '"environments-prod"');
 
   INSERT INTO puppet.hieradata (level, key, value)
-  VALUES ('environments/development', 'sample::value1', 'environments-dev');
+  VALUES ('environments/development', 'sample::value1', '"environments-dev"');
 EOF


### PR DESCRIPTION
- layout fixed
- the default value for seeds and listener set to '127.0.0.1' since otherwise tasks don't work on AWS by default
- added a cassandra-env.sh file entry listening on 127.0.0.1 to make it work with the previous change
- globally replaced "metadata" by "data"
- changed storage port to 7070 to prevent conflicts with hydra environments