### PR TITLE
Made trusted command output handling identical to the node task /show command

### DIFF
--- a/files/get-nodedata.rb
+++ b/files/get-nodedata.rb
@@ -13,13 +13,17 @@ class PuppetDataClient
   end
 
   def get_nodedata(certname:)
-    statement = @session.prepare('SELECT json puppet_environment,puppet_classes,userdata FROM nodedata WHERE name = ?').bind([certname])
+    statement = @session.prepare('SELECT puppet_environment,puppet_classes,userdata FROM nodedata WHERE name = ?').bind([certname])
     result    = @session.execute(statement)
 
     if result.first.nil?
       return {}
     else
-      return { 'nodedata' => JSON.parse(result.first['[json]']) }
+      data = result.first
+      data['puppet_classes'] = data.delete('puppet_classes').to_a unless data.nil? || data['puppet_classes'].nil?
+      data['userdata'] = JSON.parse(data.delete('userdata')) unless data.nil? || data['userdata'].nil?
+
+      { 'node' => data }
     end
   end
 end


### PR DESCRIPTION
Previously, the userdata portion of the node data was returned as a string which resulted in invalid json and a non-working trusted command.

I've replicated the "show" operation inside the node task.