### PR TITLE
Fixed hosts options parsing and puppetserver restarting

### DIFF
--- a/lib/puppet/functions/puppet_data_service/data_hash.rb
+++ b/lib/puppet/functions/puppet_data_service/data_hash.rb
@@ -26,8 +26,8 @@ Puppet::Functions.create_function(:'puppet_data_service::data_hash') do
 
   def hiera_data(options, context)
     uri = options['uri']
-    hosts = hosts.nil? ? Array(Socket.gethostname) : Array(options['hosts'])
-
+    hosts = options.key?('hosts') ? Array(options['hosts']) : Array(Socket.gethostname)
+    
     adapter = sessionadapter.adapt(closure_scope.environment)
 
     if adapter.session.nil?

--- a/manifests/puppetserver.pp
+++ b/manifests/puppetserver.pp
@@ -52,5 +52,6 @@ class puppet_data_service::puppetserver {
     value   => '/etc/puppetlabs/puppet/get-nodedata.rb',
     section => 'master',
     require => $resource_dependencies,
+    notify  => Service['pe-puppetserver'],
   }
 }


### PR DESCRIPTION
This PR changes 2 behaviors:

1. pe-puppetserver service gets restarted after `trusted_external_command` configuration in `puppet.conf` gets modified
2. Supplying a non-default hostname to the hiera backend now actually works